### PR TITLE
#489 Increase memory for catalog update

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -1708,7 +1708,7 @@ Resources:
     Properties:
       CodeUri: ../lambdas/catalog-updater
       Handler: index.handler
-      MemorySize: 128
+      MemorySize: 512
       Role: !GetAtt CatalogUpdaterLambdaExecutionRole.Arn
       Runtime: nodejs12.x
       Timeout: 20


### PR DESCRIPTION
Fixes #489

Description of changes: Increase memory for CatalogUpdaterLambdaFunction to avoid timeout that occurs with previous memory setting (128).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
